### PR TITLE
Redefine constants w/o warnings

### DIFF
--- a/lib/magentor.rb
+++ b/lib/magentor.rb
@@ -12,5 +12,7 @@ require 'xmlrpc/client'
 
 require 'magento/base'
 
-XMLRPC::Config::ENABLE_NIL_PARSER = true
-XMLRPC::Config::ENABLE_NIL_CREATE = true
+XMLRPC::Config.send(:remove_const, :ENABLE_NIL_PARSER)
+XMLRPC::Config.send(:const_set, :ENABLE_NIL_PARSER, true)
+XMLRPC::Config.send(:remove_const, :ENABLE_NIL_CREATE)
+XMLRPC::Config.send(:const_set, :ENABLE_NIL_CREATE, true)


### PR DESCRIPTION
Hi Preston,

Here's a tiny tweak to redefine XMLRPC constants without warnings

Eugene
