### PR TITLE
Simple caching

### DIFF
--- a/lib/magento/connection.rb
+++ b/lib/magento/connection.rb
@@ -11,14 +11,34 @@ module Magento
       @client = XMLRPC::Client.new(config[:host], config[:path], config[:port])
       @session = @client.call("login", config[:username], config[:api_key])
     end
-    
+
     def call(method = nil, *args)
-      @logger.debug "call: #{method}, #{args.inspect}"
-      connect
-      @client.call("call", @session, method, args)
-    rescue XMLRPC::FaultException => e
-      @logger.debug "exception: #{e.faultCode} -> #{e.faultString}"
-      raise Magento::ApiError, "#{e.faultCode} -> #{e.faultString}"
+      cache? ? call_with_caching(method, *args) : call_without_caching(method, *args)
     end
+
+    private
+
+      def cache?
+        !!config[:cache_store]
+      end
+
+      def call_without_caching(method = nil, *args)
+        @logger.debug "call: #{method}, #{args.inspect}"
+        connect
+        @client.call("call", @session, method, args)
+      rescue XMLRPC::FaultException => e
+        @logger.debug "exception: #{e.faultCode} -> #{e.faultString}"
+        raise Magento::ApiError, "#{e.faultCode} -> #{e.faultString}"
+      end
+
+      def call_with_caching(method = nil, *args)
+        config[:cache_store].fetch(cache_key(method, *args)) do
+          call_without_caching(method, *args)
+        end
+      end
+
+      def cache_key(method, *args)
+        "#{config[:username]}@#{config[:host]}:#{config[:port]}#{config[:path]}/#{method}/#{args.inspect}"
+      end
   end
 end


### PR DESCRIPTION
Hi Preston,

This adds simple caching using an ActiveSupport::Cache::Store compatible store. 

One just needs to pass a :cache_store to the Magento::Connection constuctor to enable caching like this:

```
Magento::Base.connection = Magento::Connection.new(
  :username    => "username",
  :api_key     => "apikey",
  :host        => "host",
  :path        => "/api/xmlrpc",
  :cache_store => ActiveSupport::Cache::MemoryStore.new
)
```
